### PR TITLE
#162414169 articles reactions modelmanager implementation

### DIFF
--- a/database/migrations/20190128130723-articlesReactions.js
+++ b/database/migrations/20190128130723-articlesReactions.js
@@ -1,0 +1,44 @@
+/* eslint-disable no-unused-vars */
+
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('ArticlesReactions', {
+    id: {
+      allowNull: false,
+      primaryKey: true,
+      type: Sequelize.UUID,
+      defaultValue: Sequelize.UUIDV4
+    },
+    userId: {
+      type: Sequelize.UUID,
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
+      foreignKey: true,
+      references: {
+        model: 'Users',
+        key: 'id'
+      }
+    },
+    articleId: {
+      type: Sequelize.UUID,
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
+      foreignKey: true,
+      references: {
+        model: 'Articles',
+        key: 'id'
+      }
+    },
+    reaction: {
+      type: Sequelize.STRING
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  }),
+  down: (queryInterface, Sequelize) => queryInterface.dropTable('ArticlesReactions')
+};

--- a/database/models/articles.js
+++ b/database/models/articles.js
@@ -80,6 +80,9 @@ module.exports = (sequelize, DataTypes) => {
     Articles.hasMany(models.ArticlesComments, {
       foreignKey: 'articleId'
     });
+    Articles.hasMany(models.ArticlesReactions, {
+      foreignKey: 'articleId'
+    });
     Articles.belongsToMany(models.Tags, {
       through: 'ArticleTags',
       as: 'tags',

--- a/database/models/articlesReaction.js
+++ b/database/models/articlesReaction.js
@@ -1,0 +1,24 @@
+module.exports = (sequelize, DataTypes) => {
+  const ArticlesReactions = sequelize.define(
+    'ArticlesReactions',
+    {
+      id: {
+        type: DataTypes.UUID,
+        primaryKey: true,
+        defaultValue: DataTypes.UUIDV4
+      },
+      userId: {
+        type: DataTypes.UUID
+      },
+      articleId: {
+        type: DataTypes.UUID
+      },
+      reaction: {
+        type: DataTypes.STRING,
+        allowNull: false
+      }
+    },
+    {}
+  );
+  return ArticlesReactions;
+};

--- a/database/models/user.js
+++ b/database/models/user.js
@@ -64,6 +64,9 @@ module.exports = (sequelize, DataTypes) => {
       foreignKey: 'id',
       as: 'userId'
     });
+    User.hasMany(models.ArticlesReactions, {
+      foreignKey: 'id'
+    });
   };
   return User;
 };

--- a/lib/modelManagers/articlesReactionModel.js
+++ b/lib/modelManagers/articlesReactionModel.js
@@ -1,0 +1,101 @@
+const { ArticlesReactions } = require('../../database/models');
+
+/**
+ * comments reaction model manager
+ */
+class ArticlesReaction {
+  /**
+   *
+   *
+   * @static
+   * @param {uuid} articleId
+   * @param {String} reaction
+   * @returns {Object} reaction
+   * @memberof ArticlesReaction
+   */
+  static async getArticleReactions(articleId, reaction) {
+    const reactions = await ArticlesReactions.findAndCountAll({
+      where: { articleId, reaction }
+    });
+    return reactions;
+  }
+
+  /**
+   *
+   *
+   * @static
+   * @param {uuid} articleId
+   * @param {uuid} userId
+   * @returns {Object} reaction
+   * @memberof ArticlesReaction
+   */
+  static async getUserReaction(articleId, userId) {
+    const reaction = await ArticlesReactions.findOne({
+      where: { userId, articleId },
+      attributes: ['userId', 'articleId', 'reaction']
+    });
+    return reaction;
+  }
+
+  /**
+   *
+   *
+   * @static
+   * @param {uuid} reactionId
+   * @memberof ArticlesReaction
+   * @returns {object} reaction
+   */
+  static async findReaction(reactionId) {
+    const reaction = await ArticlesReactions.findOne({
+      where: { id: reactionId }
+    });
+    return reaction;
+  }
+
+  /**
+   *
+   *
+   * @static
+   * @param {uuid} articleId
+   * @param {uuid} userId
+   * @param {string} reaction
+   * @returns {*} newReaction
+   * @memberof ArticlesReaction
+   */
+  static async createReaction(articleId, userId, reaction) {
+    const newReaction = await ArticlesReactions.create({
+      userId,
+      articleId,
+      reaction
+    });
+    return newReaction;
+  }
+
+  /**
+   * @param {string} newReaction
+   * @param {uuid} articleId
+   * @param {uuid} userId
+   * @returns {*} response
+   * @memberof ArticlesReaction
+   */
+  static async updateReaction(newReaction, articleId, userId) {
+    await ArticlesReactions.update({ reaction: newReaction }, { where: { userId, articleId } });
+  }
+
+  /**
+   *
+   *
+   * @static
+   * @param {uuid} reactionId
+   * @returns {Boolean} removedReaction
+   * @memberof ArticlesReaction
+   */
+  static async removeReaction(reactionId) {
+    const removedReaction = await ArticlesReactions.destroy({
+      where: { id: reactionId }
+    });
+    return removedReaction;
+  }
+}
+
+module.exports = ArticlesReaction;

--- a/package-lock.json
+++ b/package-lock.json
@@ -676,22 +676,22 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
           "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "requires": {
             "delegates": "^1.0.0",
@@ -700,12 +700,12 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "requires": {
             "balanced-match": "^1.0.0",
@@ -714,32 +714,32 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
           "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
@@ -747,22 +747,22 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
           "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "requires": {
             "minipass": "^2.2.1"
@@ -770,12 +770,12 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "requires": {
             "aproba": "^1.0.3",
@@ -790,7 +790,7 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -803,12 +803,12 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
@@ -816,7 +816,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "requires": {
             "minimatch": "^3.0.4"
@@ -824,7 +824,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "requires": {
             "once": "^1.3.0",
@@ -833,17 +833,17 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -851,12 +851,12 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -864,12 +864,12 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "minipass": {
           "version": "2.3.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz",
           "integrity": "sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==",
           "requires": {
             "safe-buffer": "^5.1.2",
@@ -878,19 +878,19 @@
           "dependencies": {
             "safe-buffer": {
               "version": "5.1.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
               "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
             },
             "yallist": {
               "version": "3.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
               "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
             }
           }
         },
         "minizlib": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.1.tgz",
           "integrity": "sha512-TrfjCjk4jLhcJyGMYymBH6oTXcWjYbUAXTHDbtnWHjZC25h0cdajHuPE1zxb4DVmu8crfh+HwH/WMuyLG0nHBg==",
           "requires": {
             "minipass": "^2.2.1"
@@ -898,7 +898,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "requires": {
             "minimist": "0.0.8"
@@ -906,12 +906,12 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "needle": {
           "version": "2.2.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.4.tgz",
           "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
           "requires": {
             "debug": "^2.1.2",
@@ -921,7 +921,7 @@
         },
         "node-pre-gyp": {
           "version": "0.12.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
           "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
           "requires": {
             "detect-libc": "^1.0.2",
@@ -938,7 +938,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "requires": {
             "abbrev": "1",
@@ -947,12 +947,12 @@
         },
         "npm-bundled": {
           "version": "1.0.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.5.tgz",
           "integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g=="
         },
         "npm-packlist": {
           "version": "1.1.12",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.12.tgz",
           "integrity": "sha512-WJKFOVMeAlsU/pjXuqVdzU0WfgtIBCupkEVwn+1Y0ERAbUfWw8R4GjgVbaKnUjRoD2FoQbHOCbOyT5Mbs9Lw4g==",
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -961,7 +961,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "requires": {
             "are-we-there-yet": "~1.1.2",
@@ -972,17 +972,17 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
             "wrappy": "1"
@@ -990,17 +990,17 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "requires": {
             "os-homedir": "^1.0.0",
@@ -1009,17 +1009,17 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
           "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "requires": {
             "deep-extend": "^0.6.0",
@@ -1030,14 +1030,14 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
             }
           }
         },
         "readable-stream": {
           "version": "2.3.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -1051,7 +1051,7 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "requires": {
             "glob": "^7.0.5"
@@ -1059,37 +1059,37 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
         },
         "semver": {
           "version": "5.6.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
           "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
             "code-point-at": "^1.0.0",
@@ -1099,7 +1099,7 @@
         },
         "string_decoder": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -1107,7 +1107,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -1115,12 +1115,12 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
         },
         "tar": {
           "version": "4.4.8",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
           "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "requires": {
             "chownr": "^1.1.1",
@@ -1134,24 +1134,24 @@
           "dependencies": {
             "safe-buffer": {
               "version": "5.1.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
               "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
             },
             "yallist": {
               "version": "3.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
               "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
             }
           }
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "wide-align": {
           "version": "1.1.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
           "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "requires": {
             "string-width": "^1.0.2 || 2"
@@ -1159,7 +1159,7 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         }
       }

--- a/test/mockData.js
+++ b/test/mockData.js
@@ -53,6 +53,15 @@ const userdata3 = {
   isverified: true
 };
 
+const userdata4 = {
+  id: faker.random.uuid(),
+  email: faker.internet.email(),
+  password: 'password',
+  firstname: 'firstname',
+  lastname: 'lastname',
+  isverified: true
+};
+
 const fakeUserData = {
   id: faker.random.uuid(),
   email: 'jjk@hjh.com',
@@ -156,14 +165,14 @@ const updatearticle = authorid => ({
   authorId: authorid
 });
 
-const tag = ({
+const tag = {
   tag1: 'Andela',
   tag2: 'JavaScript',
   tag3: 'Sequelize',
   invalidTag: '*&come',
   validTag: '#TIA',
   tag4: 'Java'
-});
+};
 
 const comment = (articleId, userId) => ({
   id: faker.random.uuid(),
@@ -177,6 +186,15 @@ const reaction = (commentId, UserId) => ({
   commentId,
   UserId,
   reaction: 'dislike',
+  createdAt: faker.date.recent(),
+  updatedAt: faker.date.recent()
+});
+
+const articleReaction = (articleId, userId) => ({
+  id: faker.random.uuid(),
+  articleId,
+  userId,
+  reaction: 'like',
   createdAt: faker.date.recent(),
   updatedAt: faker.date.recent()
 });
@@ -202,10 +220,9 @@ const destroyData = () => {
 };
 const returnedTag = [];
 returnedTag.push({
-  dataValues:
-   {
-     tagName: 'JavaScript'
-   },
+  dataValues: {
+    tagName: 'JavaScript'
+  }
 });
 
 const tagArray = ['JavaScript', 'Java'];
@@ -227,8 +244,10 @@ module.exports = {
   userdata2,
   userdata3,
   userprofile,
+  articleReaction,
   userprofile2,
   userprofile3,
+  userdata4,
   negativequery,
   fakeUserData,
   tag,

--- a/test/modelmanagers/articlesReaction.test.js
+++ b/test/modelmanagers/articlesReaction.test.js
@@ -1,0 +1,90 @@
+const chai = require('chai'),
+  sinonChai = require('sinon-chai'),
+  { expect, should } = chai,
+  {
+    getArticleReactions,
+    getUserReaction,
+    findReaction,
+    createReaction,
+    updateReaction,
+    removeReaction
+  } = require('../../lib/modelManagers/articlesReactionModel');
+const { Articles, ArticlesReactions } = require('../../database/models');
+const { create } = require('../../lib/modelManagers/usermodel');
+const { article, articleReaction, destroyData } = require('../mockData');
+const {
+  email, password, firstname, lastname
+} = require('../mockData').userdata4;
+
+let newUser, newArticle, newReaction;
+chai.use(sinonChai);
+chai.use(should);
+describe('Test for article reaction model', () => {
+  before(async () => {
+    destroyData();
+    newUser = await create(email, password, firstname, lastname);
+    newArticle = await Articles.create(article(newUser.id));
+    newReaction = await ArticlesReactions.create(articleReaction(newArticle.id, newUser.id));
+  });
+  after(() => {
+    destroyData();
+  });
+
+  it('Should return number of likes for an article', async () => {
+    const returnedValue = await getArticleReactions(newArticle.id, 'like');
+    expect(returnedValue).to.be.a('object');
+    expect(returnedValue).to.have.property('count');
+    expect(returnedValue).to.have.property('rows');
+    expect(returnedValue.count).to.be.eql(1);
+  });
+
+  it('Should return number of dislikes for an article', async () => {
+    const returnedValue = await getArticleReactions(newArticle.id, 'dislike');
+    expect(returnedValue).to.be.a('object');
+    expect(returnedValue).to.have.property('count');
+    expect(returnedValue).to.have.property('rows');
+    expect(returnedValue.count).to.be.eql(0);
+  });
+
+  it('Should return an existing reaction for a user', async () => {
+    const returnedValue = await getUserReaction(newArticle.id, newUser.id);
+    expect(returnedValue).to.be.an('object');
+    expect(returnedValue.dataValues.userId).to.be.eql(newUser.id);
+    expect(returnedValue.dataValues.articleId).to.be.eql(newArticle.id);
+    expect(returnedValue.dataValues.reaction).to.be.eql('like');
+  });
+
+  it('Should return reaction if the id is valid', async () => {
+    const returnedValue = await findReaction(newReaction.id);
+    expect(returnedValue).to.be.an('object');
+    expect(returnedValue.dataValues).to.have.property('userId');
+    expect(returnedValue.dataValues).to.have.property('articleId');
+    expect(returnedValue.dataValues).to.have.property('reaction');
+  });
+
+  it('Should save a new reaction to the database', async () => {
+    const articleId = newArticle.id,
+      userId = newUser.id,
+      testReaction = 'like';
+
+    const returnedValue = await createReaction(articleId, userId, testReaction);
+    expect(returnedValue).to.be.an('object');
+    expect(returnedValue.dataValues.userId).to.be.eql(newUser.id);
+    expect(returnedValue.dataValues.articleId).to.be.eql(newArticle.id);
+    expect(returnedValue.dataValues.reaction).to.be.eql('like');
+  });
+
+  it('Should update existing reaction of a user', async () => {
+    const articleId = newArticle.id,
+      userId = newUser.id,
+      testReaction = 'dislike';
+
+    await updateReaction(testReaction, articleId, userId);
+  });
+
+  it('Should delete an existing reaction of a user', async () => {
+    const returnedValue = await removeReaction(newReaction.id);
+    expect(returnedValue).to.be.a('number');
+    expect(returnedValue).to.be.eql(1);
+  });
+});

--- a/test/modelmanagers/commentsReaction.test.js
+++ b/test/modelmanagers/commentsReaction.test.js
@@ -15,7 +15,7 @@ const {
 } = require('../mockData');
 const {
   email, password, firstname, lastname
-} = require('../mockData').userdata;
+} = require('../mockData').userdata4;
 
 let newUser, newArticle, newComment, newReaction;
 chai.use(sinonChai);

--- a/test/models/articlemodel.test.js
+++ b/test/models/articlemodel.test.js
@@ -4,6 +4,7 @@ const { expect } = require('chai');
 
 const User = require('../../database/models/user');
 const Article = require('../../database/models/articles');
+const ArticlesReactions = require('../../database/models/articlesReaction');
 
 describe('Test Article Model', () => {
   const articles = Article(sequelize, dataTypes);
@@ -53,10 +54,16 @@ describe('Test Article Model', () => {
         articles.associate({
           User
         });
+        articles.associate({
+          ArticlesReactions
+        });
       });
 
       it('should have a belongsTo association with UserModel', () => {
         expect(articles.belongsTo.calledWith(User)).to.equal(true);
+      });
+      it('should have a hasMany association with ArticleReaction model', () => {
+        expect(articles.hasMany.calledWith(ArticlesReactions)).to.equal(true);
       });
     });
   });

--- a/test/models/articlesReactions.test.js
+++ b/test/models/articlesReactions.test.js
@@ -1,0 +1,25 @@
+const { sequelize, dataTypes } = require('sequelize-test-helpers');
+
+const { expect } = require('chai');
+
+const ArticlesReactions = require('../../database/models/articlesReaction');
+
+describe('Article Reaction Test', () => {
+  const ArticlesReaction = ArticlesReactions(sequelize, dataTypes);
+  const reaction = new ArticlesReaction();
+
+  describe('Check if Articles Reactions model exist', () => {
+    it('should check if ArticlesReaction has a valid model name', () => {
+      expect(ArticlesReaction.modelName).to.equal('ArticlesReactions');
+    });
+    it('should check if ArticlesReactions Model has property "userId" ', () => {
+      expect(reaction).to.have.property('userId');
+    });
+    it('should check if commentsReaction Model has property "commentId" ', () => {
+      expect(reaction).to.have.property('articleId');
+    });
+    it('should check if commentsReaction Model has property "reaction" ', () => {
+      expect(reaction).to.have.property('reaction');
+    });
+  });
+});

--- a/test/models/user.test.js
+++ b/test/models/user.test.js
@@ -4,6 +4,7 @@ const { expect } = require('chai');
 
 const profile = require('../../database/models/userprofile');
 const User = require('../../database/models/user');
+const ArticlesReactions = require('../../database/models/articlesReaction');
 
 describe('User Model', () => {
   const users = User(sequelize, dataTypes);
@@ -31,12 +32,16 @@ describe('User Model', () => {
     context('Check the User Model associations', () => {
       before(() => {
         users.associate({
-          profile,
+          profile
+        });
+        users.associate({
+          ArticlesReactions
         });
       });
 
-      it('should have a one-to-one association with the profile Model', () => {
-
+      it('should have a one-to-one association with the profile Model', () => {});
+      it('should have a hasMany association with ArticleReaction model', () => {
+        expect(users.hasMany.calledWith(ArticlesReactions)).to.equal(true);
       });
     });
   });


### PR DESCRIPTION
**What does this PR do?**
Creates modelmanager for ArticlesReactions for necessary `db` operations

**Description of Task to be completed**
A user should be able to like and dislike an article
A user should be able to cancel initial reaction on an article
A user should see all likes for an article they are currently viewing

**How should this be manually tested ?**
Clone the repository and run `npm test` on command line
After the tests pass, use the command sequelize db:migrate to generate appropriate tables in the database

**Any background context ?**
The reactions model manager can only work as expected if the project contains the required 
models and migration files. Make sure you look out for these two files.
`articlesReaction.js` and `20190128130723-articlesReactions.js` 

**What are the relevant pivotal tracker stories ?**
Users should be able to like and or dislike articles